### PR TITLE
Fix Popper Props Children Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "awesome-typescript-loader": "^5.2.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
-    "babel-plugin-emotion": "^9.2.11",
     "babel-plugin-require-context-hook": "^1.0.0",
     "chokidar-cli": "^1.2.2",
     "codecov": "^3.3.0",
@@ -108,7 +107,7 @@
     "ts-jest": "^24.0.2",
     "tslint": "^5.16.0",
     "tslint-react": "^4.0.0",
-    "typescript": "^3.4.5",
+    "typescript": "^3.5.3",
     "webfonts-generator": "^0.4.0",
     "webpack": "^4.29.6"
   },

--- a/packages/pebble-web/src/components/DropDown.tsx
+++ b/packages/pebble-web/src/components/DropDown.tsx
@@ -93,7 +93,7 @@ class DropDown extends React.PureComponent<DropdownProps, DropdownState> {
                 className={cx(dropDownStyle, dropDownClassName)}
                 style={{ padding, ...transitionStyles }}
               >
-                <Popper {...this.props} positionFixed>
+                <Popper {...this.props}>
                   {({ ref, style, placement, arrowProps }) => {
                     const popperWrapperStyle = {
                       ...style,

--- a/packages/pebble-web/src/components/Tooltip.tsx
+++ b/packages/pebble-web/src/components/Tooltip.tsx
@@ -59,7 +59,6 @@ class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
       <Popper
         label={() => label({ ref: this.labelRef })}
         placement={placement}
-        positionFixed
         controlled
         popperBackgroundColor={isError ? colors.red.base : colors.gray.darker}
         modifiers={modifiers}

--- a/packages/pebble-web/src/components/typings/Popper.ts
+++ b/packages/pebble-web/src/components/typings/Popper.ts
@@ -6,8 +6,8 @@ type Label =
   | number
   | ((args: { toggle: () => void; isOpen: boolean }) => React.ReactNode);
 
-// @ts-ignore
-export interface PopperProps extends Partial<PopperProps_> {
+export interface PopperProps
+  extends Omit<PopperProps_, "positionFixed" | "children"> {
   label: Label;
   popperBackgroundColor?: string;
   children: (args: { toggle: () => void; isOpen: boolean }) => React.ReactNode;

--- a/packages/pebble-web/stories/popper.story.tsx
+++ b/packages/pebble-web/stories/popper.story.tsx
@@ -6,7 +6,6 @@ storiesOf("Components/Popper", module).add("simple", () => (
   <Popper
     label={({ toggle }) => <Button onClick={toggle}>Click Me</Button>}
     placement="left"
-    positionFixed
     modifiers={{
       preventOverflow: {
         enabled: false

--- a/yarn.lock
+++ b/yarn.lock
@@ -15586,10 +15586,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
Exporting Types strips the ts-ignore comments.
So this was erroring build in anarock.website.
