### PR TITLE
Remove `any` Type in Tooltip implementation

### DIFF
--- a/packages/pebble-shared/stories/icons.story.tsx
+++ b/packages/pebble-shared/stories/icons.story.tsx
@@ -30,7 +30,7 @@ storiesOf("Theme/icons", module).add("List", () => (
   <div className={wrapper}>
     {iconNames.map((iconName: string) => (
       <div key={iconName} style={{ width: "33%" }}>
-        <Tooltip
+        <Tooltip<HTMLDivElement>
           label={({ ref }) => (
             <div className={divs} ref={ref}>
               <i className={`pi pi-${iconName}`} /> <span>{iconName}</span>

--- a/packages/pebble-web/src/components/Tooltip.tsx
+++ b/packages/pebble-web/src/components/Tooltip.tsx
@@ -4,7 +4,10 @@ import { TooltipProps, TooltipState } from "./typings/Tooltip";
 import { colors } from "pebble-shared";
 import { popperStyle, textStyle } from "./styles/Tooltip.styles";
 
-class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
+class Tooltip<T extends HTMLElement> extends React.PureComponent<
+  TooltipProps<T>,
+  TooltipState
+> {
   state = {
     isOpen: !!this.props.isOpen
   };
@@ -13,8 +16,7 @@ class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
     <span className={textStyle}>{this.props.text}</span>
   );
 
-  // tslint:disable-next-line no-any
-  labelRef: React.RefObject<any> = React.createRef();
+  labelRef: React.RefObject<T> = React.createRef();
 
   private showTooltip = () =>
     this.setState({
@@ -27,15 +29,17 @@ class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
     });
 
   private addListeners = () => {
-    if (!this.props.disabled) {
+    if (!this.props.disabled && this.labelRef.current) {
       this.labelRef.current.addEventListener("mouseenter", this.showTooltip);
       this.labelRef.current.addEventListener("mouseleave", this.hideTooltip);
     }
   };
 
   private removeListeners = () => {
-    this.labelRef.current.removeEventListener("mouseenter", this.showTooltip);
-    this.labelRef.current.removeEventListener("mouseleave", this.showTooltip);
+    if (this.labelRef.current) {
+      this.labelRef.current.removeEventListener("mouseenter", this.showTooltip);
+      this.labelRef.current.removeEventListener("mouseleave", this.showTooltip);
+    }
   };
 
   componentDidMount() {
@@ -46,7 +50,7 @@ class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
     this.removeListeners();
   }
 
-  componentDidUpdate(prevProps: TooltipProps) {
+  componentDidUpdate(prevProps: TooltipProps<T>) {
     if (prevProps.disabled !== this.props.disabled) {
       this.props.disabled ? this.removeListeners() : this.addListeners();
     }

--- a/packages/pebble-web/src/components/Tooltip.tsx
+++ b/packages/pebble-web/src/components/Tooltip.tsx
@@ -29,13 +29,13 @@ class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
   private addListeners = () => {
     if (!this.props.disabled) {
       this.labelRef.current.addEventListener("mouseenter", this.showTooltip);
-      this.labelRef.current.addEventListener("mouseout", this.hideTooltip);
+      this.labelRef.current.addEventListener("mouseleave", this.hideTooltip);
     }
   };
 
   private removeListeners = () => {
     this.labelRef.current.removeEventListener("mouseenter", this.showTooltip);
-    this.labelRef.current.removeEventListener("mouseout", this.showTooltip);
+    this.labelRef.current.removeEventListener("mouseleave", this.showTooltip);
   };
 
   componentDidMount() {

--- a/packages/pebble-web/src/components/typings/Tooltip.ts
+++ b/packages/pebble-web/src/components/typings/Tooltip.ts
@@ -1,14 +1,15 @@
 import * as PopperJS from "popper.js";
 
-export interface TooltipProps {
+export interface TooltipProps<T extends HTMLElement> {
   text: React.ReactNode;
   placement?: PopperJS.Placement;
   modifiers?: PopperJS.Modifiers;
   isOpen?: boolean;
   isError?: boolean;
   disabled?: boolean;
-  // tslint:disable-next-line no-any
-  label: (args: { ref: React.RefObject<any> }) => React.ReactNode;
+  label: (args: {
+    ref: React.RefObject<T>;
+  }) => React.DetailedHTMLProps<React.HTMLAttributes<T>, T>;
   renderElement?: (args: {
     toggle: () => void;
     isOpen: boolean;

--- a/packages/pebble-web/src/components/typings/Tooltip.ts
+++ b/packages/pebble-web/src/components/typings/Tooltip.ts
@@ -7,9 +7,7 @@ export interface TooltipProps<T extends HTMLElement> {
   isOpen?: boolean;
   isError?: boolean;
   disabled?: boolean;
-  label: (args: {
-    ref: React.RefObject<T>;
-  }) => React.DetailedHTMLProps<React.HTMLAttributes<T>, T>;
+  label: (args: { ref: React.RefObject<T> }) => React.ReactNode;
   renderElement?: (args: {
     toggle: () => void;
     isOpen: boolean;

--- a/packages/pebble-web/stories/tooltip.story.tsx
+++ b/packages/pebble-web/stories/tooltip.story.tsx
@@ -24,7 +24,7 @@ const placements = [
 ] as Placement[];
 
 storiesOf("Components/Tooltip", module).add("simple", () => (
-  <Tooltip
+  <Tooltip<HTMLDivElement>
     label={({ ref }) => (
       <div ref={ref}>
         <Button type="link" onClick={() => {}}>


### PR DESCRIPTION
Not so happy about this as will have to do:
```tsx
<Tooltip<HTMLDivElement>
  {...props}
/>
```

Opening a PR, if anyone else has a better suggestion.