### PR TITLE
remove DateInput placeholder suffix "DD/MM/YYYY"

### DIFF
--- a/packages/pebble-web/src/components/DateInput.tsx
+++ b/packages/pebble-web/src/components/DateInput.tsx
@@ -100,7 +100,7 @@ export default class DateInput extends React.PureComponent<
                 onChange={noop}
                 type={"tel"}
                 value={value}
-                placeholder={`${placeholder} DD/MM/YYYY`}
+                placeholder={placeholder}
                 onClick={() => {
                   if (disabled) return;
                   toggleDropdown();

--- a/packages/pebble-web/src/components/__tests__/dateInput.test.tsx
+++ b/packages/pebble-web/src/components/__tests__/dateInput.test.tsx
@@ -12,14 +12,15 @@ describe("DateInput", () => {
     const changeSpy = sinon.spy();
 
     const dateInput = mount(
-      <DateInput placeholder="Select Date" onChange={changeSpy} value={date} />
+      <DateInput
+        placeholder="Select Date DD/MM/YYYY"
+        onChange={changeSpy}
+        value={date}
+      />
     );
     dateInput.find(Input).simulate("click");
 
-    dateInput
-      .find(".react-calendar__tile")
-      .at(0)
-      .simulate("click");
+    dateInput.find(".react-calendar__tile").at(0).simulate("click");
 
     expect(changeSpy.calledOnce).toBeTruthy();
 


### PR DESCRIPTION
https://dateinput-placeholder-suffix--5cb6f92366a0080020cba496.chromatic.com/?path=/story/components-input--date

<details>
<summary>codemod to update props (using <code>ts-morph</code>)</summary>

```ts
// clear console
console.log("\x1Bc");

import { JsxAttribute, Project, Node } from "ts-morph";

// project base directory
// const projectDir = "/path/to/pebble/packages/pebble-web";
// const projectDir = "/path/to/anarock.crm";


// definition file
// const defFile = "src/components/typings/DateInput.ts";
// const defFile = "node_modules/pebble-web/dist/components/typings/DateInput.d.ts";

const suffix = "DD/MM/YYYY";

const project = new Project({
  tsConfigFilePath: projectDir + "/tsconfig.json",
});

project
  .getSourceFileOrThrow(projectDir + "/" + defFile)
  .getInterface("DateInputProps")
  .getProperty("placeholder")
  .findReferencesAsNodes()
  .map((propRef) => propRef.getParent() as JsxAttribute)
  .forEach((prop) => {
    const file = prop.getSourceFile();
    const path = file.getFilePath();
    const { line, column } = file.getLineAndColumnAtPos(prop.getStart());
    console.log("file:\n" + `${path}:${line}:${column}`);

    const before = prop.getText();
    console.log("before:\n" + before);

    const propValue = prop.getInitializer();
    if (Node.isStringLiteral(propValue)) {
      const value = propValue.getText().slice(1, -1);
      const newValue = value === "" ? `"${suffix}"` : `"${value} ${suffix}"`;
      propValue.replaceWithText(newValue);
    } else if (Node.isJsxExpression(propValue)) {
      const y = propValue.getExpression();
      if (Node.isTemplateExpression(y)) {
        const value = y.getText().slice(1, -1);
        const newValue = `\`${value} ${suffix}\``;
        y.replaceWithText(newValue);
      } else if (Node.isIdentifier(y)) {
        const value = y.getText();
        const newValue = `\`\${${value}} ${suffix}\``;
        y.replaceWithText(newValue);
      }
    }

    const after = prop.getText();
    console.log("after:\n" + after);

    console.log();
  });

project.saveSync();
```